### PR TITLE
Fixed SenseGlove_Grabable.InteractionEnd throwing a null reference ex…

### DIFF
--- a/SenseGlove/Scripts/Interaction/SenseGlove_Grabable.cs
+++ b/SenseGlove/Scripts/Interaction/SenseGlove_Grabable.cs
@@ -187,8 +187,11 @@ public class SenseGlove_Grabable : SenseGlove_Interactable
 
             if (this.IsInteracting())
             {   //break every possible instance that could connect this interactable to the grabscript.
-                this.pickupReference.parent = this.originalParent;
-
+				if(this.pickupReference != null)
+				{
+					this.pickupReference.parent = this.originalParent;
+				}
+				
                 this.BreakJoint();
 
                 if (this.physicsBody != null)


### PR DESCRIPTION
Fixed SenseGlove_Grabable.InteractionEnd throwing a null reference exception if you destroyed the attached object while holding it.